### PR TITLE
Added new navbar layout for logged in user.

### DIFF
--- a/layout/header.php
+++ b/layout/header.php
@@ -26,6 +26,18 @@
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+					<?php if (isset($_SESSION['is_logged'])): ?>
+					<li class="nav-item">
+						<div class="dropdown">
+							<button class="btn btn-outline-light dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-expanded="false">
+							<?php echo $_SESSION['is_logged']['fullname']; ?>
+							</button>
+							<div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+								<a class="dropdown-item" href="<?php echo $url->base_url().'logout.php'; ?>">Logout</a>
+							</div>
+						</div>
+					</li>
+					<?php else: ?>
                     <!-- <li class="nav-item"><a class="nav-link active" aria-current="page" href="#">Home</a></li> -->
                     <li class="nav-item"><a class="nav-link" href="<?php echo $url->base_url().'login.php'; ?>">Login</a></li>
                     <li class="nav-item"><a class="nav-link" href="<?php echo $url->base_url().'register.php'; ?>">Register</a></li>
@@ -39,6 +51,7 @@
                             <li><a class="dropdown-item" href="#">Something else here</a></li>
                         </ul>
                     </li> -->
+					<?php endif; ?>
                 </ul>
             </div>
         </div>

--- a/layout/header.php
+++ b/layout/header.php
@@ -27,14 +27,12 @@
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
 					<?php if (isset($_SESSION['is_logged'])): ?>
-					<li class="nav-item">
-						<div class="dropdown">
-							<button class="btn btn-outline-light dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-expanded="false">
-							<?php echo $_SESSION['is_logged']['fullname']; ?>
-							</button>
-							<div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-								<a class="dropdown-item" href="<?php echo $url->base_url().'logout.php'; ?>">Logout</a>
-							</div>
+					<li class="nav-item dropdown">
+						<button class="btn text-light dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-expanded="false">
+						<?php echo $_SESSION['is_logged']['fullname']; ?>
+						</button>
+						<div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+							<a class="dropdown-item" href="<?php echo $url->base_url().'logout.php'; ?>">Logout</a>
 						</div>
 					</li>
 					<?php else: ?>


### PR DESCRIPTION
Instead of showing "Login" and "Register" options for logged in users, the navigation bar now shows a drop-down with username in the button and a "Logout" option in the drop-down menu.

Default navbar:
![navbar_old](https://user-images.githubusercontent.com/59551367/143730170-6c6b2de7-e7f4-4686-a196-73acdb457940.png)

Navbar for logged in users:
![navbar_new1](https://user-images.githubusercontent.com/59551367/143730184-17b7eb5e-f616-47da-a5b3-98d7e2ac1b35.png)

Navbar for logged in user (with drop-down menu open):
![navbar_new2](https://user-images.githubusercontent.com/59551367/143730197-41bea475-b909-41a1-8cc2-28a3a88da3be.png)

Signed-off-by: Drevcus <dyron76@gmail.com>